### PR TITLE
Added bit_iterator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 2.8)
 add_subdirectory(unit)
 add_subdirectory(tools)
+add_subdirectory(perf)
 enable_testing()

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: tags
+.PHONY: tags perf
 
 all:
 	mkdir -p build
@@ -17,6 +17,10 @@ clean:
 
 test: all
 	make CTEST_OUTPUT_ON_FAILURE=1 -C build test
+
+perf: test
+	build/perf/ictperf --ibits
+	build/perf/ictperf --obits
 
 tags: 
 	mkdir -p o

--- a/README.md
+++ b/README.md
@@ -40,5 +40,3 @@ heirarchies that benefit from both cache friendly locality of reference and C++1
 
 Although using the tools does not require any source files, running the unit tests does.  Just type `make` at the top
 level to invoke the cmake based build system.  And `make test` will run the unit tests.
-
-

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Intrig C++ Tools
 
 **ict** is a small set of openly available reusable components originally developed and used by Intrig for its
-next-generation message decoding engine.  They are a result of countless hours of programming missteps, restarts, and
-refactoring.  
+next-generation message decoding engine.
 
 The goal of **ict** is to provide useful independent components with a natural, simple interface enabling you to
 concentrate on your task at hand, not wrestle with the tools you are using. The only dependency is the standard template
@@ -14,9 +13,13 @@ released under the permissive MIT license.
 Initially, two components are available, with more to come: `ict::bitstring` and `ict::multivector`.  Below is a brief
 description and links to their respective documentation.  
 
-Everything here is a work in progress.  Nothing is a complete implementation.  There are definitely gaps in the features
-provided.  We tend to only implement the functionality we need.  Hopefully you will find ways to contribute the things
-you need also.
+Everything here is a work in progress.  There are definitely gaps in the features provided.  We tend to only implement
+the functionality we need.  Hopefully you will find ways to contribute the things you need also.
+
+The intended use is for you to add ict as a submodule to your projects include directory.  From time to time, you can
+then update when new features are added.  However, strict backward compatibility is not a priority for ict development
+and the release version will indicate if anything has changed.
+
 
 ## ict::bitstring
 
@@ -26,7 +29,7 @@ and integers.  Corresponding input and output streams for bits are provided with
 `ict::obitstream`.  This enables you to easily dissect or catenate bitstrings without being concerned with byte
 alignment.
 
-**[ict::bitstring reference](docs/bitstring.md)**
+**[ict::bitstring tutorial and reference](docs/bitstring.md)**
 
 ## ict::multivector
 
@@ -34,7 +37,7 @@ A `multivector` is a generic container that behaves just like a `std::vector` ex
 behave just like `std::vector`.  And since `std::vector` is used in the underlying representation, we can make
 heirarchies that benefit from both cache friendly locality of reference and C++11 move semantics.
 
-**[ict::multivector reference](docs/multivector.md)**
+**[ict::multivector tutorial and reference](docs/multivector.md)**
 
 ## Building unit tests
 

--- a/bitstring.h
+++ b/bitstring.h
@@ -566,7 +566,7 @@ struct ibitstream {
 
     // peek ahead
     bitstring peek(size_t n, size_t offset=0) {
-        return bitstring(bit_index, bit_index + offset);
+        return bitstring(bit_index + n, bit_index + n + offset);
     }
 
     size_t tellg() const { return index; }

--- a/bitstring.h
+++ b/bitstring.h
@@ -206,11 +206,12 @@ inline void prepare_first_copy(A & src_len, B const dst_offset_modulo, C * dst, 
 
 }
 
-inline void bit_copy(bit_type src, size_t bit_count, bit_type dest) {
-    const unsigned char * src_org = (const unsigned char *) src.byte;
-    int src_offset = src.bit;
-    unsigned char *dst_org = (unsigned char *) dest.byte;
-    int dst_offset = dest.bit;
+using bit_iterator = util::bit_iterator;
+inline void bit_copy_n(bit_iterator & first, size_t bit_count, bit_iterator & result) {
+    const unsigned char * src_org = (const unsigned char *) first->byte;
+    int src_offset = first->bit;
+    unsigned char *dst_org = (unsigned char *) result->byte;
+    int dst_offset = result->bit;
     static const unsigned char reverse_mask[] =
         { 0x00, 0x80, 0xc0, 0xe0, 0xf0, 0xf8, 0xfc, 0xfe, 0xff };
     static const unsigned char reverse_mask_xor[] =
@@ -306,16 +307,10 @@ inline void bit_copy(bit_type src, size_t bit_count, bit_type dest) {
     }
 }
 
-using bit_iterator = util::bit_iterator;
 
 // no return iterator for performance reasons
 inline void bit_copy(bit_iterator first, bit_iterator last, bit_iterator result) {
-    bit_copy(*first, last - first, *result);
-}
-
-inline void bit_copy_n(bit_iterator first, size_t bit_count, bit_iterator result) {
-    // bit_copy({first->byte, first->bit}, bit_count, {result->byte, result->bit});
-    bit_copy(first, first + bit_count, result);
+    bit_copy_n(first, last - first, result);
 }
 
 struct bitstring {

--- a/bitstring.h
+++ b/bitstring.h
@@ -98,10 +98,10 @@ struct bit_type {
     mutable size_t bit;
 };
 
-template <typename T>
 struct bit_iterator {
     bit_iterator() : value(nullptr, 0) {}
-    bit_iterator(T p, size_t b = 0) : value(p, b) {}
+    bit_iterator(char * p, size_t b = 0) : value(p, b) {}
+    bit_iterator(unsigned char * p, size_t b = 0) : value((char *)p, b) {}
     bit_iterator(const bit_iterator & b) : value(b.value) {}
     bit_type & operator*() const { return value; }
     bit_type * operator->() const { return &(operator*()); }
@@ -301,8 +301,7 @@ inline void bit_copy(bit_view dest, const_bit_view src, size_t src_len) {
     }
 }
 
-using bit_iterator = util::bit_iterator<char *>;
-using const_bit_iterator = util::bit_iterator<const char *>;
+using bit_iterator = util::bit_iterator;
 
 // no return iterator for performance reasons
 inline void bit_copy(bit_iterator first, bit_iterator last, bit_iterator result) {
@@ -331,6 +330,12 @@ struct bitstring {
         bit_copy(first, last, bit_begin());
     }
 
+    bitstring(bit_iterator first, size_t len) {
+        alloc(len);
+        bit_copy(first, first + len, bit_begin());
+    }
+
+
     template <typename T>
     bitstring(T first, T last) {
         auto f = bit_iterator(&(*first));
@@ -347,7 +352,7 @@ struct bitstring {
         a.bit_size_ = 0;
     }
 
-#if 1
+#if 0
     // 101001
     // f.....l
     // bit_size = 6
@@ -919,7 +924,7 @@ inline bitstring random_bitstring(size_t bit_len) {
     auto bytes = bit_len / 8 + 1;
     auto v = std::vector<unsigned char>(bytes);
     for (auto & b : v) b = engine();
-    return ict::bitstring(v.begin(), bit_len);
+    return ict::bitstring(bit_iterator(v.data()), bit_len);
 }
 
 inline std::string gsm7(const bitstring & bits, size_t fill_bits = 0)

--- a/bitstring.h
+++ b/bitstring.h
@@ -41,7 +41,7 @@ struct const_bit_view {
 
 // bit proxy type
 struct bit_type {
-    bit_type(char * byte, size_t bit) : byte(byte + (bit / 8)), bit(bit % 8) {}
+    bit_type(char * byte, size_t bit) : byte(byte), bit(bit) {}
 
     bool value() const {
         return get_bit(byte, bit);

--- a/bitstring.h
+++ b/bitstring.h
@@ -206,7 +206,7 @@ inline void prepare_first_copy(A & src_len, B const dst_offset_modulo, C * dst, 
 
 }
 
-inline void bit_copy(bit_type dest, bit_type src, size_t bit_count) {
+inline void bit_copy(bit_type src, size_t bit_count, bit_type dest) {
     const unsigned char * src_org = (const unsigned char *) src.byte;
     int src_offset = src.bit;
     unsigned char *dst_org = (unsigned char *) dest.byte;
@@ -304,10 +304,6 @@ inline void bit_copy(bit_type dest, bit_type src, size_t bit_count) {
             }
         }
     }
-}
-
-inline void bit_copy(bit_type src, size_t bit_len, bit_type result) {
-    bit_copy(result, src, bit_len);
 }
 
 using bit_iterator = util::bit_iterator;

--- a/bitstring.h
+++ b/bitstring.h
@@ -526,25 +526,23 @@ struct ibitstream {
 
     ibitstream(const bitstring & bits) : bits(bits) {
         index = 0;
-        bit_index = bits.bit_begin();
         end_list.push_back(bits.bit_size());
         mark();
     }
 
     void advance() {
         ++index;
-        ++bit_index;
     }
     void advance(size_t n) {
         index += n;
-        bit_index += n;
     }
 
     // read up to n bits blindly
     bitstring read_blind(size_t n) {
-        auto f = bit_index;
         advance(n);
-        return bitstring(f, bit_index);
+        return bitstring(bits.begin(), n, index - n);
+        // auto f = bit_index;
+        // return bitstring(f, bit_index);
     }
 
     // read up to n bits
@@ -566,7 +564,11 @@ struct ibitstream {
 
     // peek ahead
     bitstring peek(size_t n, size_t offset=0) {
-        return bitstring(bit_index + n, bit_index + n + offset);
+#if 0
+        return bitstring(bit_index, bit_index + offset);
+#else
+        return bitstring(bits.begin(), n, index + offset);
+#endif
     }
 
     size_t tellg() const { return index; }
@@ -606,7 +608,7 @@ struct ibitstream {
 
     private:
     const bitstring & bits;
-    bit_iterator bit_index;
+    // bit_iterator bit_index;
     size_t index = 0;
     std::vector<size_t> end_list;
     std::vector<size_t> marker_list;

--- a/bitstring.h
+++ b/bitstring.h
@@ -23,9 +23,8 @@ struct const_bit_view {
 
 namespace util {
 
-template <typename T>
-struct bit_base {
-    bit_base(T byte, size_t bit) : byte(byte + (bit / 8)), bit(bit % 8) {}
+struct bit_type {
+    bit_type(char * byte, size_t bit) : byte(byte + (bit / 8)), bit(bit % 8) {}
     
     void increment() {
         ++bit;
@@ -34,38 +33,34 @@ struct bit_base {
         bit += n;
     }
 
-    void decrement(size_t n) {
-        auto t = byte * 8 + bit; // TODO: overflow 
-        t -= n;
-        byte = t / 8;
-        bit = t % 8;
-    }
-
     void decrement() {
-        if (bit == 0) {
+        if (bit) --bit;
+        else {
             bit = 7;
             --byte;
-        } else {
-            --bit;
         }
     }
 
-    size_t difference(const bit_base & b) {
+    void decrement(size_t n) {
+        // TODO implement as O(1)
+        for (auto i = 0; i<n; ++i) decrement();
+    }
+
+    size_t difference(const bit_type & b) {
         auto bytes = byte - b.byte;
         auto bits = bit - b.bit;
         return (bytes * 8) + bits;
     }
 
-    bool identical(const bit_base & b) {
+    bool identical(const bit_type & b) {
         return byte == b.byte && bit == b.bit;
     }
-    T byte;
+    char * byte;
     size_t bit;
 };
 
 template <typename T>
 struct bit_iterator {
-    using bit_type = bit_base<T>;
     bit_iterator() : value(nullptr, 0) {}
     bit_iterator(T p, size_t b) : value(p, b) {}
     bit_iterator(const bit_iterator & b) : value(b.value) {}

--- a/bitstring.h
+++ b/bitstring.h
@@ -524,25 +524,32 @@ struct ibitstream {
 
     ibitstream(const ibitstream &) = delete;
 
-    ibitstream(const bitstring & bits) : bits(bits) {
+    ibitstream(const bitstring & bits_) : bits(bits_) {
         index = 0;
+        bit_index = bits.begin();
         end_list.push_back(bits.bit_size());
         mark();
     }
 
     void advance() {
         ++index;
+        ++bit_index;
     }
     void advance(size_t n) {
         index += n;
+        bit_index += n;
     }
 
     // read up to n bits blindly
     bitstring read_blind(size_t n) {
+#if 1
         advance(n);
         return bitstring(bits.begin(), n, index - n);
-        // auto f = bit_index;
-        // return bitstring(f, bit_index);
+#else
+        auto f = bit_index;
+        advance(n);
+        return bitstring(f, n);
+#endif
     }
 
     // read up to n bits
@@ -608,7 +615,7 @@ struct ibitstream {
 
     private:
     const bitstring & bits;
-    // bit_iterator bit_index;
+    bit_iterator bit_index;
     size_t index = 0;
     std::vector<size_t> end_list;
     std::vector<size_t> marker_list;

--- a/bitstring.h
+++ b/bitstring.h
@@ -28,27 +28,10 @@ struct bit_base {
     bit_base(T byte, size_t bit) : byte(byte + (bit / 8)), bit(bit % 8) {}
     
     void increment() {
-#if 1
         ++bit;
-#else // seems like we don't have to do this
-        if (bit == 7) {
-            bit = 0;
-            ++byte;
-        } else {
-            ++bit;
-        }
-#endif
     }
     void increment(size_t n) {
-#if 1
         bit += n;
-#else
-        bit += n;
-        if (bit > 7) {
-            byte += bit / 8;
-            bit = bit % 8;
-        }
-#endif
     }
 
     void decrement(size_t n) {
@@ -349,12 +332,8 @@ struct bitstring {
 
     bitstring(const pointer first, size_t bit_size, unsigned source_offset) {
         alloc(bit_size);
-#if 1
         auto f = bit_iterator(first, source_offset);
         bit_copy(f, f + bit_size, bit_begin());
-#else
-        bit_copy({begin(), 0}, {first, source_offset}, bit_size);
-#endif
     }
 
     bitstring(int base, const char * str); 
@@ -553,11 +532,7 @@ struct ibitstream {
 
     // peek ahead
     bitstring peek(size_t n, size_t offset=0) {
-#if 1
         return bitstring(bit_index, bit_index + offset);
-#else
-        return bitstring(bits.begin(), n, index + offset);
-#endif
     }
 
     size_t tellg() const { return index; }
@@ -740,11 +715,7 @@ inline T to_integer(bitstring const & bits, bool swap = true) {
                 // we are converting a bitstring to a bigger type.  So copy the bitstring into the last 
                 // bits of the number,
                 // leaving the first bits as zero.  Then swap and return.
-#if 1
                 bit_copy(bits.bit_begin(), bits.bit_end(), bit_iterator((char *)&number, type_size - bits.bit_size()));
-#else
-                bit_copy({ (char *)&number, type_size - bits.bit_size()} , { bits.begin(), 0 }, bits.bit_size());
-#endif
                 if (swap) reverse_bytes<T>(number);
                 return (T) number;
                 break;

--- a/bitstring.h
+++ b/bitstring.h
@@ -206,7 +206,7 @@ inline void prepare_first_copy(A & src_len, B const dst_offset_modulo, C * dst, 
 
 }
 
-inline void bit_copy(bit_view dest, const_bit_view src, size_t src_len) {
+inline void bit_copy(util::bit_type dest, util::bit_type src, size_t src_len) {
     const unsigned char * src_org = (const unsigned char *) src.byte;
     int src_offset = src.bit;
     unsigned char *dst_org = (unsigned char *) dest.byte;
@@ -776,7 +776,7 @@ inline T to_integer(bitstring const & bits, bool swap = true) {
 // 11
 inline bitstring& bitstring::remove(size_t index, size_t len) {
     obitstream os;
-    os << substr(0, index) << substr(index + len);
+    os << bitstring(bit_begin(), index) << bitstring(bit_begin() + index + len, bit_end());
     *this = os.bits();
     return *this;
 }
@@ -937,7 +937,8 @@ inline std::string gsm7(const bitstring & bits, size_t fill_bits = 0)
     bs.remove(8 - fill_bits, len);
 
     // get the first character
-    auto pre = bs.substr(0, 7);
+    auto pre = bitstring(bs.bit_begin(), 7);
+    // auto pre = bs.substr(0, 7);
     pre = util::pad_left(pre, 8);
     auto first = gsm7(pre);
 

--- a/docs/bitstring.md
+++ b/docs/bitstring.md
@@ -93,7 +93,7 @@ bitstring(size_t bit_size);         // bitstring filled with 0 bits
 bitstring(const bitstring & a);     // copy constructor
 bitstring(bitstring && a) noexcept; // move constructor
 
-// bitstring from input iterators.  These can can be `bit_iterators` described above, or traditional iterators.
+// bitstring from input iterators.  These can can be bit_iterators described above, or traditional iterators.
 bitstring(InputIterator first, InputIterator last);
 
 // bitstring from an input iterator and bit length.
@@ -146,17 +146,14 @@ auto a = is.read(3); // a = @111
 auto b = is.read(3); // b = @000
 ```
 
-```c++
-struct ibitstream {
-```
 The only way to create an `ibitstream` is to initialize its constructor with a `bitstring`.  
 
 ```c++
 ibitstream() = delete;
 ibitstream(const ibitstream &) = delete;
-ibitstream(const bitstring & bits) : bits(bits) 
+ibitstream(const bitstring & bits)
 
-// read up n bits blindly.  Values of n greater than remaining() result in undefined behavior.
+// Read n bits.  Values of n greater than remaining() result in undefined behavior.
 bitstring read_blind(size_t n) 
 
 bitstring read(size_t n) // read up to n bits

--- a/docs/multivector.md
+++ b/docs/multivector.md
@@ -9,37 +9,34 @@
     * 1.2 [Download ](#1.2)
 * 2 [Cursors ](#2)
     * 2.1 [multivector<T>::cursor ](#2.1)
-* 3 [multivector<T>::ascending_cursor ](#3)
-* 4 [multivector<T>::linear_cursor ](#4)
-* 5 [Functions ](#5)
-    * 5.1 [get_root ](#5.1)
-    * 5.2 [previous ](#5.2)
-    * 5.3 [recurse ](#5.3)
-    * 5.4 [recurse (2) ](#5.4)
-    * 5.5 [compact_string ](#5.5)
-    * 5.6 [to_text ](#5.6)
-    * 5.7 [leaf ](#5.7)
-    * 5.8 [promote_last ](#5.8)
-    * 5.9 [to_ascending ](#5.9)
-    * 5.10 [to_linear ](#5.10)
-    * 5.11 [append ](#5.11)
-* 6 [References ](#6)
+    * 2.2 [multivector<T>::ascending_cursor ](#2.2)
+    * 2.3 [multivector<T>::linear_cursor ](#2.3)
+* 3 [Functions ](#3)
+    * 3.1 [get_root ](#3.1)
+    * 3.2 [previous ](#3.2)
+    * 3.3 [recurse ](#3.3)
+    * 3.4 [recurse (2) ](#3.4)
+    * 3.5 [compact_string ](#3.5)
+    * 3.6 [to_text ](#3.6)
+    * 3.7 [leaf ](#3.7)
+    * 3.8 [promote_last ](#3.8)
+    * 3.9 [to_ascending ](#3.9)
+    * 3.10 [to_linear ](#3.10)
+    * 3.11 [append ](#3.11)
+* 4 [References ](#4)
 
 ##<a name="1"/>1 Introduction 
 
 
-Often, our data structures require more complexity than `std::vector` provides, and that's when we shift to using a node
-based structure.  Perhaps its one we write (and maintain) ourselves, or one found in the reference section below.  
-
-A multivector attempts to provide a hierarchical data structure with the convenience of a `std::vector`.
+A multivector to provide a hierarchical data structure with the convenience of a `std::vector`.
 
 It is a generic container that behaves just like a `std::vector` except its iterators also
 behave just like `std::vector`.  And since `std::vector` is used in the underlying representation, we can make
 hierarchies that benefit from both cache friendly locality of reference and C++11 move semantics.
 
-A multivector is not an all-purpose tree representation.  It is optimised to handle trees with nodes that are 
-likely to have siblings and less likely to have children.  This is exactly the kind of trees we find through computer
-programming: HTML, XML, user interface window hierarchies, telecom messages, configurators, *more examples*, etc. 
+A multivector is optimised to handle trees with nodes that are likely to have siblings and less likely to have children.
+This is exactly the kind of trees we find throughout computer programming: HTML, XML, user interface window hierarchies,
+telecom messages, configurators, multiple choice tests, *more examples*, etc. 
 
 ###<a name="1.1"/>1.1 Example 
 
@@ -168,7 +165,7 @@ bool is_root() const // true if this is the root cursor
 Cursor validity is similar to that of vectors.  If a sibling vector gets resized, then all its cursors are invalidated.
 But any parent cursor is still valid.
 
-##<a name="3"/>3 multivector<T>::ascending_cursor 
+###<a name="2.2"/>2.2 multivector<T>::ascending_cursor 
 
 
 An ascending cursor is a forward cursor.  `operator++` just goes up and to the left until the root.
@@ -218,7 +215,7 @@ Additional ascending cursor operations:
 ```c++
 bool is_root() const
 ```
-##<a name="4"/>4 multivector<T>::linear_cursor 
+###<a name="2.3"/>2.3 multivector<T>::linear_cursor 
 
 
 A linear cursor is also a forward iterator.  It traverses a multivector in a depth-first order.
@@ -243,13 +240,13 @@ Notice the automatic conversion from one type of cursor to another.
 
 There are no operations for the linear cursor other than those of an input iterator.
 
-##<a name="5"/>5 Functions 
+##<a name="3"/>3 Functions 
 
 
 The multivector functions act upon one or more template cursor parameters that must satisfy the cursor 
 definition above.
 
-###<a name="5.1"/>5.1 get_root 
+###<a name="3.1"/>3.1 get_root 
 
 
 ```c++
@@ -258,7 +255,7 @@ Cursor get_root(Cursor start)
 ```
 
 Return the root cursor of a multivector given a cursor.  This is a log2(n) operation.
-###<a name="5.2"/>5.2 previous 
+###<a name="3.2"/>3.2 previous 
 
 ```c++
 template <typename Cursor>
@@ -266,7 +263,7 @@ Cursor previous(Cursor self)
 ```
 
 Return the previous cursor, either a sibling or parent.
-###<a name="5.3"/>5.3 recurse 
+###<a name="3.3"/>3.3 recurse 
 
 ```c++
 template <typename Cursor, typename Action>
@@ -286,7 +283,7 @@ typedef ict::multivector<int>::cursor int_cursor;
 auto m = ict::multivector<int>{1, { 2, { 3 }}};
 ict::recurse(m.root(), [](int_cursor c, int_cursor) { std::cout << *c << '\n'; }
 ```
-###<a name="5.4"/>5.4 recurse (2) 
+###<a name="3.4"/>3.4 recurse (2) 
 
 
 ```c++
@@ -297,7 +294,7 @@ void recurse(Cursor parent, Action action_down, Action action_up, int level = 0)
 This version of recurse is similar to the above, except it also performs and action on the way up.
 Also, the current depth in the tree will be provided.
 
-###<a name="5.5"/>5.5 compact_string 
+###<a name="3.5"/>3.5 compact_string 
 
 ```c++
 inline std::string compact_string(Cursor parent);
@@ -314,7 +311,7 @@ std::cout << ict::compact_string(m.root());
 prints:
 
 `{1 {2 {3}}}`
-###<a name="5.6"/>5.6 to_text 
+###<a name="3.6"/>3.6 to_text 
 
 ```c++
 inline std::string to_text(Cursor parent)
@@ -323,13 +320,13 @@ inline std::string to_text(const multivector<T> & tree)
 
 Convert to a table string.  An example is provided in the introduction.
 
-###<a name="5.7"/>5.7 leaf 
+###<a name="3.7"/>3.7 leaf 
 
 
 `inline Cursor leaf(Cursor c)`
 
 Returns the last child of c or c if it is empty().
-###<a name="5.8"/>5.8 promote_last 
+###<a name="3.8"/>3.8 promote_last 
 
 
 `inline void promote_last(Cursor parent)`
@@ -337,17 +334,17 @@ Returns the last child of c or c if it is empty().
 Replace the last child with the children of the last child.  This should be rewritten to not be so specific.  There
 should be a detach() ability that removes a subtree as a multivector.
 
-###<a name="5.9"/>5.9 to_ascending 
+###<a name="3.9"/>3.9 to_ascending 
 
 `inline typename Cursor::ascending_cursor_type to_ascending(Cursor parent)`
 
 Convert a cursor to an ascending cursor.
-###<a name="5.10"/>5.10 to_linear 
+###<a name="3.10"/>3.10 to_linear 
 
 `inline typename Cursor::linear_type to_linear(Cursor parent)`
 
 Convert a cursor to a linear cursor.
-###<a name="5.11"/>5.11 append 
+###<a name="3.11"/>3.11 append 
 
 ```c++
 template <typename Cursor, typename ConstCursor>
@@ -359,7 +356,7 @@ void append(Cursor parent, ConstCursor from_parent)
 
 Append (i.e., copy) the children of one cursor to the children of another.  The the children will be
 appended to any existing children.
-##<a name="6"/>6 References 
+##<a name="4"/>4 References 
 
 
 Below are other tree implementations and papers I looked at while developing multivector.  In general, they provide

--- a/perf/CMakeLists.txt
+++ b/perf/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 2.8)
+add_definitions(-std=c++11)
+include_directories(..)
+add_executable(ictperf ictperf.cpp)

--- a/perf/ictperf.cpp
+++ b/perf/ictperf.cpp
@@ -1,0 +1,81 @@
+#include <bitstring.h>
+#include <command.h>
+#include <ict.h>
+
+using std::cerr;
+
+void out_bits() {
+}
+
+template <typename Op>
+void time_op(int n, Op op) {
+    ict::timer time;
+    time.start();
+    for (int i = 0; i < n; ++i) op();
+    time.stop();
+    cerr << time << '\n';
+};
+
+template <typename Op, typename EndOp>
+void time_op(int n, Op op, EndOp end_op) {
+    ict::timer time;
+    time.start();
+    for (int i = 0; i < n; ++i) op();
+    end_op();
+    time.stop();
+    cerr << time << '\n';
+};
+
+void in_bits(int s, int n) {
+    // create a giant bitstring
+    auto bits = ict::random_bitstring(1024);
+
+    time_op(n, [&]() {
+        ict::ibitstream ibs(bits);
+        while (!ibs.eobits()) {
+            auto bits = ibs.read(s);
+        }
+    });
+}
+
+void out_bits(int s, int n) {
+    // create a giant bitstring
+    auto bits = ict::random_bitstring(s);
+
+    ict::obitstream obs;
+    time_op(n, 
+    [&]() {
+        obs << bits;
+    },
+    [&]() {
+        auto x = obs.bits();
+    }
+    );
+}
+
+int main(int argc, char **argv) {
+    bool input = false;
+    bool output = false;
+    try {
+        ict::command line("ictperf", "ict performance tests", "ictperf [options]");
+        line.add(ict::option("ibits", 'i', "input bitstream", [&]{ input = true; }));
+        line.add(ict::option("obits", 'o', "output bitstream", [&]{ output = true; }));
+
+        line.parse(argc, argv);
+        if (input) {
+            in_bits(3, 100000);
+            in_bits(5, 100000);
+            in_bits(8, 100000);
+            in_bits(11, 100000);
+        };
+
+        if (output) {
+            out_bits(3, 10000000);
+            out_bits(5, 10000000);
+            out_bits(8, 10000000);
+            out_bits(11, 10000000);
+        }
+    } catch (std::exception & e) {
+    }
+
+}

--- a/unit/bitstring/bitstringunit.cpp
+++ b/unit/bitstring/bitstringunit.cpp
@@ -701,18 +701,18 @@ void bitstring_unit::iterators() {
         }
         IT_ASSERT(x == y);
     }
-#if 0
-#endif
 
 }
 
 void bitstring_unit::const_iterators() {
+#if 0
     const_bit_iterator first;
     ++first;
     first++;
     auto x = *first;
     --first;
     first--;
+#endif
 
 }
 

--- a/unit/bitstring/bitstringunit.cpp
+++ b/unit/bitstring/bitstringunit.cpp
@@ -683,8 +683,26 @@ void bitstring_unit::iterators() {
         first++;
         first--;
         IT_ASSERT(first == y);
+        first += 10;
+        y += 10;
+        IT_ASSERT(first == y);
+        IT_ASSERT(y == first);
+        auto z = y;
+        z -= 10;
+        IT_ASSERT(z == x.bit_begin());
     }
 
+    {
+        auto x = random_bitstring(1024);
+        auto y = bitstring(1024);
+
+        for (auto i = x.bit_begin(), j = y.bit_begin(); i!=x.bit_end(); ++i, ++j) {
+            j->value(*i);
+        }
+        IT_ASSERT(x == y);
+    }
+#if 0
+#endif
 
 }
 

--- a/unit/bitstring/bitstringunit.cpp
+++ b/unit/bitstring/bitstringunit.cpp
@@ -191,9 +191,9 @@ void bitstring_unit::ibs() {
     IT_ASSERT(!is2.eobits());
 
     auto a = is2.read(1);
-    IT_ASSERT(!is2.eobits());
-    IT_ASSERT(is2.remaining() == 5);
     IT_ASSERT(a == "@1");
+    IT_ASSERT_MSG(is2.remaining(), is2.remaining() == 5);
+    IT_ASSERT(!is2.eobits());
 
     a = is2.read(3);
     IT_ASSERT(!is2.eobits());
@@ -564,6 +564,7 @@ void bitstring_unit::modern_gsm7()
 
         // 6, 1
         IT_ASSERT(bs1.substr(0, 6) == "@111100");
+        IT_ASSERT(ict::bitstring(bs1.bit_begin(), bs1.bit_begin() + 6) == "@111100");
         IT_ASSERT(bs1.substr(6 + 1, 15 - (6 + 1)) == "@11111010");
     }
     {

--- a/unit/bitstring/bitstringunit.cpp
+++ b/unit/bitstring/bitstringunit.cpp
@@ -643,6 +643,18 @@ void bitstring_unit::modern_sms_difficult()
     IT_ASSERT(ict::gsm7(sm) == result.c_str());
 }
 
+void random_copy(int n) {
+    auto bs = random_bitstring(n);
+    auto l = bs.bit_end() - bs.bit_begin();
+    IT_ASSERT_MSG(l << " != " << n, l == n);
+    auto x = bitstring(n);
+    // std::cerr << "copying " << bs << '\n';
+    bit_copy(bs.bit_begin(), bs.bit_end(), x.bit_begin());
+    IT_ASSERT(bs.bit_size() == n);
+    IT_ASSERT(x.bit_size() == n);
+    IT_ASSERT_MSG("copying " << n << " bits: " << bs << " == " << x, bs == x);
+}
+
 void bitstring_unit::iterators() {
     bit_iterator first;
     IT_ASSERT(first == bit_iterator());
@@ -656,9 +668,11 @@ void bitstring_unit::iterators() {
     {
         auto bs = bitstring("@111001");
         auto x = bitstring(bs.bit_size());
+        IT_ASSERT(bs.bit_end() - bs.bit_begin() == 6);
         ict::bit_copy(bs.bit_begin(), bs.bit_end(), x.bit_begin());
-        IT_ASSERT(bs == x);
+        IT_ASSERT_MSG(bs  << " != " << x, bs == x);
     }
+    for (auto n = 1; n < 1024; ++n) random_copy(n);
 
 
 }

--- a/unit/bitstring/bitstringunit.cpp
+++ b/unit/bitstring/bitstringunit.cpp
@@ -675,6 +675,16 @@ void bitstring_unit::iterators() {
     }
     for (auto n = 1; n < 1024; ++n) random_copy(n);
 
+    {
+        auto x = random_bitstring(1024);
+        auto first = x.bit_begin();
+        auto y = first;
+        IT_ASSERT(first == y);
+        first++;
+        first--;
+        IT_ASSERT(first == y);
+    }
+
 
 }
 

--- a/unit/bitstring/bitstringunit.cpp
+++ b/unit/bitstring/bitstringunit.cpp
@@ -644,7 +644,27 @@ void bitstring_unit::modern_sms_difficult()
 }
 
 void bitstring_unit::iterators() {
-    bitstring::bit_iterator first;
+    bit_iterator first;
+    IT_ASSERT(first == bit_iterator());
+    ++first;
+    first++;
+    auto x = *first;
+    --first;
+    first--;
+    IT_ASSERT(first == bit_iterator());
+
+    {
+        auto bs = bitstring("@111001");
+        auto x = bitstring(bs.bit_size());
+        ict::bit_copy(bs.bit_begin(), bs.bit_end(), x.bit_begin());
+        IT_ASSERT(bs == x);
+    }
+
+
+}
+
+void bitstring_unit::const_iterators() {
+    const_bit_iterator first;
     ++first;
     first++;
     auto x = *first;

--- a/unit/bitstring/bitstringunit.cpp
+++ b/unit/bitstring/bitstringunit.cpp
@@ -643,6 +643,17 @@ void bitstring_unit::modern_sms_difficult()
     IT_ASSERT(ict::gsm7(sm) == result.c_str());
 }
 
+void bitstring_unit::iterators() {
+    bitstring::bit_iterator first;
+    ++first;
+    first++;
+    auto x = *first;
+    --first;
+    first--;
+
+}
+
+
 }
 int main (int, char **) {
     ict::bitstring_unit test;

--- a/unit/bitstring/bitstringunit.h
+++ b/unit/bitstring/bitstringunit.h
@@ -31,6 +31,7 @@ class bitstring_unit
         ut.add(&bitstring_unit::modern_sms_difficult);
 
         ut.add(&bitstring_unit::iterators);
+        ut.add(&bitstring_unit::const_iterators);
 
         ut.skip();
         ut.cont();
@@ -56,5 +57,6 @@ class bitstring_unit
     void modern_gsm7();
     void modern_sms_difficult();
     void iterators();
+    void const_iterators();
 };
 }

--- a/unit/bitstring/bitstringunit.h
+++ b/unit/bitstring/bitstringunit.h
@@ -30,6 +30,8 @@ class bitstring_unit
         ut.add(&bitstring_unit::modern_gsm7);
         ut.add(&bitstring_unit::modern_sms_difficult);
 
+        ut.add(&bitstring_unit::iterators);
+
         ut.skip();
         ut.cont();
     }
@@ -53,5 +55,6 @@ class bitstring_unit
     void modern_replace();
     void modern_gsm7();
     void modern_sms_difficult();
+    void iterators();
 };
 }


### PR DESCRIPTION
Improved the ict::bitstring API by adding bit_iterators and then using them through out.  This simplified the constructors and the copy functions.  Unit tests were added and passed.  

Dropped confusing oddball constructors and the copy functions that took 5 parameters in favor of the new ones.

There was no performance degradation.

Updated documentation accordingly.
