### PR TITLE
multivector constructor now explicit

### DIFF
--- a/docs/multivector.md
+++ b/docs/multivector.md
@@ -371,3 +371,4 @@ more capability than the multivector, but are node based.
 
 * [Hierarchical Data Structures and Related Concepts for the C++ Standard Library](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3700.html)
 
+* [LCRS Binary Tree](https://en.wikipedia.org/wiki/Left-child_right-sibling_binary_tree)

--- a/multivector.h
+++ b/multivector.h
@@ -614,9 +614,14 @@ inline std::ostringstream & operator<<(std::ostringstream & ss, typename item<T>
 // return the root cursor of a multivector given a cursor
 template <typename Cursor>
 Cursor get_root(Cursor start) {
+#if 1
+    while (!start.is_root()) start = start.parent();
+    return start;
+#else
     auto r = typename Cursor::ascending_cursor_type(start);
     while (!r.is_root()) ++r;
     return r;
+#endif
 }
 
 // return the previous cursor, either a sibling or parent

--- a/multivector.h
+++ b/multivector.h
@@ -514,7 +514,7 @@ struct multivector {
     };
 
     // Conversions
-    multivector(cursor a) : root_(a.item_ref()) {
+    explicit multivector(cursor a) : root_(a.item_ref()) {
         root_.value = value_type(); // weird
         root_.parent = (item<value_type> *)(-1);
     }

--- a/tools/mvcli.cpp
+++ b/tools/mvcli.cpp
@@ -204,7 +204,7 @@ void custom() {
     std::cout << "\nnow create custom message:\n";
     std::cout << ict::to_text(tree) << "\n";
 
-    ict::multivector<Custom> sub = tree.begin();
+    auto sub = ict::multivector<Custom>(tree.begin());
     std::cout << "\nnow create a sub message:\n";
     std::cout << ict::to_text(sub) << "\n";
 }


### PR DESCRIPTION
The multivector constructor that takes a cursor as a parameter is now explicit.  This relieves ambiguity issues with functions that take either a multivector or a cursor.
